### PR TITLE
fixes #1

### DIFF
--- a/autoload/lsbuffer.vim
+++ b/autoload/lsbuffer.vim
@@ -41,7 +41,7 @@ function! s:delete(lnr) abort
             endif
             call delete(fname, 'rf')
         endif
-    elseif glob(fname)
+    elseif !empty(glob(fname))
         call delete(fname)
     else
         echohl ErrorMsg


### PR DESCRIPTION
`if glob(..)` will usually fail since strings are false unless they begin with a non-zero number.